### PR TITLE
Fix for parse error in files.handlebars

### DIFF
--- a/partials/files.handlebars
+++ b/partials/files.handlebars
@@ -1,5 +1,5 @@
 <div class="page-header">
-    <h1>{{{fileName}} <small>File</small></h1>
+    <h1>{{fileName}} <small>File</small></h1>
 </div>
 
 <div class="file">


### PR DESCRIPTION
Heya,

I get following error when compiling the docs.

The attached change fixes an issue for me.

```
$ grunt yui-doc-compile
Running "yuidoc:compile" (yuidoc) task
Start YUIDoc compile...
Scanning: src/widgets
Output: dist/demos/api
Fatal error: Parse error on line 2:
...    <h1>{{{fileName}} <small>File</smal
----------------------^
Expecting 'CLOSE_UNESCAPED', got 'CLOSE'
```

```
$ node -v
v0.10.25
$ npm -v
1.3.24
```
