### PR TITLE
Enable linking to specific props/methods/events

### DIFF
--- a/assets/js/yuidoc-bootstrap.js
+++ b/assets/js/yuidoc-bootstrap.js
@@ -77,13 +77,59 @@ $(function() {
         }
     }
 
+    function scrollToAnchor($anchor) {
+        var navbarHeight = $('.navbar-fixed-top').outerHeight(true);
+        $(document).scrollTop( $anchor.offset().top - navbarHeight);
+    }
+
+    $('[data-toggle=tab]').on('click', function (event, extraArgs) {
+        // Why?  If responding to the click of a link or hashchange already, we really
+        //  don't want to change window hash
+        if (extraArgs && extraArgs.ignore === true) {
+            return;
+        }
+        window.location.hash = $(this).attr('href');
+    });
+
     $('[data-tabid]').on('click', function(event) {
         var tabToActivate = $(this).attr('data-tabid'),
         anchor = $(this).attr('data-anchor');
         event.preventDefault();
+
         $('[data-toggle=tab][href="'+ tabToActivate + '"]').click();
-        $(document).scrollTop( $(anchor).offset().top );
+        scrollToAnchor($(anchor));
+        window.location.hash = anchor;
     });
+
+    function moveToWindowHash() {
+        var hash = window.location.hash,
+            $anchor = $(hash),
+            tabToActivate = hash,
+            $tabToActivate = false;
+
+        if (!hash) {
+            return;
+        }
+
+        if (hash.match(/^#method_/)) {
+            tabToActivate = '#methods';
+        }
+        else if (hash.match(/^#property_/)) {
+            tabToActivate = '#properties';
+        }
+        else if (hash.match(/^#event_/)) {
+            tabToActivate = '#event';
+        }
+
+        $tabToActivate = $('[data-toggle=tab][href="'+ tabToActivate + '"]');
+        if ($tabToActivate.length) {
+            $tabToActivate.trigger('click', { ignore: true });
+        }
+
+        if ($anchor.length) {
+            scrollToAnchor($(hash));
+        }
+    }
 
     // ************************************************************************* //
     //  Initializations + Event listeners
@@ -183,6 +229,10 @@ $(function() {
         }
     });
 
+    function setUpHashChange() {
+        $(window).on('hashchange', moveToWindowHash);
+    }
+
 
     // ************************************************************************* //
     //  Immediate function calls
@@ -191,5 +241,9 @@ $(function() {
     setUpActiveTab();
     setUpOptionsCheckboxes();
     setUpWidgets();
+    setUpHashChange();
+    if (window.location.hash) {
+        moveToWindowHash();
+    }
 
 });


### PR DESCRIPTION
So, good theme of course, thanks kindly all.

But one thing that's annoyed me for a while is that one can't link to specific docs.  Say I have a class with 50 properties or something crazy - it's unreasonable to ask the user to search for a specific one after linking to the class.

So instead, now you could pass them a link like `BASE_URL#property_oneOf50` and they would get linked right to the property.  

Also useful and related is that when a user clicks a particular link, say to that oneOf50 property, it changes the window hash correspondingly.
