### PR TITLE
De-indent layout_content

### DIFF
--- a/layouts/main.handlebars
+++ b/layouts/main.handlebars
@@ -44,7 +44,7 @@
             <div class="apidocs">
                 <div id="docs-main">
                     <div class="content">
-                        {{>layout_content}}
+{{>layout_content}}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Indenting the layout_content lead to visibly added spaces in code snippets.

Fixes https://github.com/kevinlacotaco/yuidoc-bootstrap-theme/issues/21